### PR TITLE
Fix description of contains Quality, fixes #1

### DIFF
--- a/confidence-core/src/main/java/org/saynotobugs/confidence/quality/map/EntryOf.java
+++ b/confidence-core/src/main/java/org/saynotobugs/confidence/quality/map/EntryOf.java
@@ -62,11 +62,11 @@ public final class EntryOf<K, V> extends QualityComposition<Map.Entry<K, V>>
     public EntryOf(Quality<? super K> key, Quality<? super V> value)
     {
         super(new DescribedAs<>(description -> new Composite(
-            new TextDescription("Entry { "),
+            new TextDescription("Entry ( "),
             key.description(),
             new TextDescription(": "),
             value.description(),
-            new TextDescription(" }")),
+            new TextDescription(" )")),
             new AllOf<>(
                 new Has<>(Map.Entry::getKey, key),
                 new Has<>(Map.Entry::getValue, value)

--- a/confidence-core/src/test/java/org/saynotobugs/confidence/quality/array/ArrayThatTest.java
+++ b/confidence-core/src/test/java/org/saynotobugs/confidence/quality/array/ArrayThatTest.java
@@ -19,10 +19,10 @@ class ArrayThatTest
         assertThat(new ArrayThat(new Contains<>(3)),
             new AllOf<>(
                 new Passes<Object>(new int[] { 1, 2, 3 }, new int[] { 3 }, new int[] { 3, 3, 3, 3, 3 }),
-                new Fails<Object>(new int[] {}, "(1) array [  ] did not contain <3>"),
-                new Fails<Object>(new int[] { 1, 2, 4 }, "(1) array [ <1>,\n  <2>,\n  <4> ] did not contain <3>"),
+                new Fails<Object>(new int[] {}, "(1) array [  ] did not contain { <3> }"),
+                new Fails<Object>(new int[] { 1, 2, 4 }, "(1) array [ <1>,\n  <2>,\n  <4> ] did not contain { <3> }"),
                 new Fails<>("abc", "(0) not an array"),
-                new HasDescription("(0) an array\n  and\n  (1) array that contains <3>")
+                new HasDescription("(0) an array\n  and\n  (1) array that contains { <3> }")
             ));
     }
 

--- a/confidence-core/src/test/java/org/saynotobugs/confidence/quality/iterable/ContainsTest.java
+++ b/confidence-core/src/test/java/org/saynotobugs/confidence/quality/iterable/ContainsTest.java
@@ -23,9 +23,9 @@ class ContainsTest
         assertThat(new Contains<>(123),
             new AllOf<>(
                 new Passes<>(new Seq<>(123), new Seq<>(1, 2, 3, 123)),
-                new Fails<Iterable<Integer>>(emptyIterable(), "[  ] did not contain <123>"),
-                new Fails<Iterable<Integer>>(new Seq<>(1, 2, 3), "[ <1>,\n  <2>,\n  <3> ] did not contain <123>"),
-                new HasDescription("contains <123>")
+                new Fails<Iterable<Integer>>(emptyIterable(), "[  ] did not contain { <123> }"),
+                new Fails<Iterable<Integer>>(new Seq<>(1, 2, 3), "[ <1>,\n  <2>,\n  <3> ] did not contain { <123> }"),
+                new HasDescription("contains { <123> }")
             ));
     }
 
@@ -42,10 +42,10 @@ class ContainsTest
                     new Seq<>(0, 1, 2, 3, 123),
                     new Seq<>(3, 2, 3, 123, 1)),
                 new Fails<Iterable<Integer>>(emptyIterable(),
-                    "{ [  ] did not contain <1>\n  and\n  [  ] did not contain <2>\n  and\n  [  ] did not contain <3> }"),
-                new Fails<Iterable<Integer>>(new Seq<>(1, 2), "{ ...\n  [ <1>,\n    <2> ] did not contain <3> }"),
-                new Fails<Iterable<Integer>>(new Seq<>(1, 2, 2, 2), "{ ...\n  [ <1>,\n    <2>,\n    <2>,\n    <2> ] did not contain <3> }"),
-                new HasDescription("contains <1>\n  and\n  contains <2>\n  and\n  contains <3>")
+                    "[  ] did not contain { <1>,\n  <2>,\n  <3> }"),
+                new Fails<Iterable<Integer>>(new Seq<>(1, 2), "[ <1>,\n  <2> ] did not contain { <3> }"),
+                new Fails<Iterable<Integer>>(new Seq<>(1, 2, 2, 2), "[ <1>,\n  <2>,\n  <2>,\n  <2> ] did not contain { <3> }"),
+                new HasDescription("contains { <1>,\n  <2>,\n  <3> }")
             ));
     }
 
@@ -62,12 +62,13 @@ class ContainsTest
                     new Seq<>(1, 0, 2, 3, 123),
                     new Seq<>(4, 2, 3, 123, 0)),
                 new Fails<Iterable<Integer>>(emptyIterable(),
-                    "{ [  ] did not contain less than <1>\n  and\n  [  ] did not contain <2>\n  and\n  [  ] did not contain greater than <3> }"),
-                new Fails<Iterable<Integer>>(new Seq<>(0, 2), "{ ...\n  [ <0>,\n    <2> ] did not contain greater than <3> }"),
-                new Fails<Iterable<Integer>>(new Seq<>(-10, 5, 6, 7), "{ ...\n  [ <-10>,\n    <5>,\n    <6>,\n    <7> ] did not contain <2>\n  ... }"),
+                    "[  ] did not contain { less than <1>,\n  <2>,\n  greater than <3> }"),
+                new Fails<Iterable<Integer>>(new Seq<>(2), "[ <2> ] did not contain { less than <1>,\n  greater than <3> }"),
+                new Fails<Iterable<Integer>>(new Seq<>(0, 2), "[ <0>,\n  <2> ] did not contain { greater than <3> }"),
+                new Fails<Iterable<Integer>>(new Seq<>(-10, 5, 6, 7), "[ <-10>,\n  <5>,\n  <6>,\n  <7> ] did not contain { <2> }"),
                 new Fails<Iterable<Integer>>(new Seq<>(1, 2, 2, 10, 100),
-                    "{ [ <1>,\n    <2>,\n    <2>,\n    <10>,\n    <100> ] did not contain less than <1>\n  ... }"),
-                new HasDescription("contains less than <1>\n  and\n  contains <2>\n  and\n  contains greater than <3>")
+                    "[ <1>,\n  <2>,\n  <2>,\n  <10>,\n  <100> ] did not contain { less than <1> }"),
+                new HasDescription("contains { less than <1>,\n  <2>,\n  greater than <3> }")
             ));
     }
 }

--- a/confidence-core/src/test/java/org/saynotobugs/confidence/quality/map/EntryOfTest.java
+++ b/confidence-core/src/test/java/org/saynotobugs/confidence/quality/map/EntryOfTest.java
@@ -21,8 +21,8 @@ class EntryOfTest
         assertThat(new EntryOf<>(new EqualTo<>(12), new EqualTo<>("abc")),
             new AllOf<>(
                 new Passes<>(entry(12, "abc")),
-                new Fails<>(entry(13, "ab"), "Entry { <12>: \"abc\" }"),
-                new HasDescription("Entry { <12>: \"abc\" }")
+                new Fails<>(entry(13, "ab"), "Entry ( <12>: \"abc\" )"),
+                new HasDescription("Entry ( <12>: \"abc\" )")
             ));
     }
 

--- a/confidence-core/src/test/java/org/saynotobugs/confidence/quality/map/HasEntryTest.java
+++ b/confidence-core/src/test/java/org/saynotobugs/confidence/quality/map/HasEntryTest.java
@@ -26,10 +26,10 @@ class HasEntryTest
         assertThat(new HasEntry<>("k1", "v1"),
             new AllOf<>(
                 new Passes<>(map1),
-                new Fails<>(new HashMap<String, String>(), "{  } did not contain Entry { \"k1\": \"v1\" }"),
-                new Fails<>(map2, "{ \"k2\": \"v2\" } did not contain Entry { \"k1\": \"v1\" }"),
+                new Fails<>(new HashMap<String, String>(), "{  } did not contain { Entry ( \"k1\": \"v1\" ) }"),
+                new Fails<>(map2, "{ \"k2\": \"v2\" } did not contain { Entry ( \"k1\": \"v1\" ) }"),
                 //  new Fails<>(Map.of("k2", "v2"), new DescribesAs("")),
-                new HasDescription("contains Entry { \"k1\": \"v1\" }")
+                new HasDescription("contains { Entry ( \"k1\": \"v1\" ) }")
             ));
 
     }

--- a/confidence-rxjava3/src/test/java/org/saynotobugs/confidence/rxjava3/quality/CompletableThatTest.java
+++ b/confidence-rxjava3/src/test/java/org/saynotobugs/confidence/rxjava3/quality/CompletableThatTest.java
@@ -35,7 +35,7 @@ class CompletableThatTest
         assertThat(new CompletableThat<>(new IsAlive<>()),
             new AllOf<>(
                 new Passes<>(ignored -> Completable.never()),
-                new Fails<>(ignored -> Completable.error(IOException::new), "Completable that (0) was has error contains <anything>\n  ..."),
+                new Fails<>(ignored -> Completable.error(IOException::new), "Completable that (0) was has error contains { <anything> }\n  ..."),
                 new Fails<>(ignored -> Completable.complete(), "Completable that (0) was ...\n  completes exactly once\n  ..."),
                 new HasDescription("Completable that (0) alive")
             ));


### PR DESCRIPTION
reduces the redundancy in the `contains` Quality description and makes it
more readable in general.