### PR TITLE
Fix Absent Generic Type, fixes #17

### DIFF
--- a/confidence-core/src/main/java/org/saynotobugs/confidence/quality/optional/Absent.java
+++ b/confidence-core/src/main/java/org/saynotobugs/confidence/quality/optional/Absent.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 
 
 @StaticFactories(value = "Core", packageName = "org.saynotobugs.confidence.quality")
-public final class Absent<T> extends QualityComposition<Optional<T>>
+public final class Absent extends QualityComposition<Optional<?>>
 {
     /**
      * Matches empty {@link Optional}s.
@@ -36,6 +36,6 @@ public final class Absent<T> extends QualityComposition<Optional<T>>
     {
         super(new Satisfies<>(
             actual -> !actual.isPresent(),
-            new TextDescription("<empty> optional")));
+            new TextDescription("<absent>")));
     }
 }

--- a/confidence-core/src/test/java/org/saynotobugs/confidence/quality/optional/AbsentTest.java
+++ b/confidence-core/src/test/java/org/saynotobugs/confidence/quality/optional/AbsentTest.java
@@ -17,11 +17,11 @@ class AbsentTest
     @Test
     void test()
     {
-        assertThat(new Absent<>(),
+        assertThat(new Absent(),
             new AllOf<>(
                 new Passes<Optional<Integer>>(Optional.empty()),
                 new Fails<>(Optional.of(123), "<present <123>>"),
-                new HasDescription("<empty> optional")
+                new HasDescription("<absent>")
             ));
     }
 


### PR DESCRIPTION
The Quality of an empty Optional doesn't care about the actual value
type.