### PR TITLE
Let Has take a ThrowingFunction, closes #38

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.dmfs.gitversion' version '0.7.0'
+    id 'org.dmfs.gitversion' version '0.14.1'
 }
 
 gitVersion {
@@ -10,28 +10,30 @@ gitVersion {
         }
     }
     changes {
-        are major when {
-            commitMessage contains("(?i)#major\\b")
+        are none when {
+            affects only(matches(~/.*\.md/))
         }
         are major when {
-            commitMessage contains("(?i)#break\\b")
+            commitMessage contains(~/(?i)#(major|break(ing)?)\b/)
         }
         are minor when {
-            commitMessage containsIssue { issue -> issue.labels?.every { it.name != "bug" } }
+            commitMessage contains(~/(?i)#(?<issue>\d+)\b/) {
+                where("issue") { isIssue { labeled "enhancement" } }
+            }
         }
         are patch when {
-            commitMessage containsIssue { issue -> issue.labels?.any { it.name == "bug" } }
+            commitMessage contains(~/(?i)#(?<issue>\d+)\b/) {
+                where("issue") { isIssue { labeled "bug" } }
+            }
         }
         are minor when {
             commitMessage contains("#feature\\b")
         }
-        are minor when {
-            commitMessage contains("(?i)\\b(implement(s|ed)?|close[sd]?) #\\d+\\b")
-        }
-        are patch when {
-            commitMessage contains("(?i)\\b(fix(e[sd])?|resolve[sd]?) #\\d+\\b")
-        }
         otherwise patch
+    }
+    preReleases {
+        on ~/main/ use { "beta" }
+        on ~/(.*\/)?(?<name>.*)/ use { "alpha-${group('name')}.1" }
     }
     releaseBranchPattern ~/main$/
 }

--- a/confidence-core/build.gradle
+++ b/confidence-core/build.gradle
@@ -11,10 +11,10 @@ dependencies {
     compileOnly 'org.dmfs:srcless-annotations:0.1.0'
     annotationProcessor 'org.dmfs:srcless-processors:0.1.0'
     compileOnly 'org.hamcrest:hamcrest:2.2'
-    implementation 'org.dmfs:jems2:2.8.0'
+    implementation 'org.dmfs:jems2:2.14.0'
 
     testImplementation project(':confidence-test')
-    testImplementation 'org.dmfs:jems2-testing:2.8.0'
+    testImplementation 'org.dmfs:jems2-testing:2.14.0'
     testImplementation 'org.hamcrest:hamcrest:2.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'

--- a/confidence-core/src/main/java/org/saynotobugs/confidence/quality/composite/Has.java
+++ b/confidence-core/src/main/java/org/saynotobugs/confidence/quality/composite/Has.java
@@ -19,27 +19,32 @@
 package org.saynotobugs.confidence.quality.composite;
 
 import org.dmfs.jems2.Function;
+import org.dmfs.jems2.ThrowingFunction;
 import org.dmfs.srcless.annotations.staticfactory.StaticFactories;
 import org.saynotobugs.confidence.Description;
 import org.saynotobugs.confidence.Quality;
-import org.saynotobugs.confidence.assessment.FailPrepended;
+import org.saynotobugs.confidence.assessment.Fail;
 import org.saynotobugs.confidence.assessment.FailUpdated;
 import org.saynotobugs.confidence.description.Delimited;
 import org.saynotobugs.confidence.description.TextDescription;
+import org.saynotobugs.confidence.description.ValueDescription;
+import org.saynotobugs.confidence.utils.FailSafe;
 
 
 @StaticFactories(value = "Core", packageName = "org.saynotobugs.confidence.quality")
 public final class Has<T, V> extends QualityComposition<T>
 {
 
-    public Has(Function<? super T, ? extends V> featureFunction, Quality<? super V> delegate)
+    public Has(ThrowingFunction<? super T, ? extends V> featureFunction, Quality<? super V> delegate)
     {
-        super(actual -> delegate.assessmentOf(featureFunction.value(actual)),
-            delegate.description());
+        this(delegateFeatureDescription -> delegateFeatureDescription,
+            featureMismatchDescription -> featureMismatchDescription,
+            featureFunction,
+            delegate);
     }
 
 
-    public Has(String featureName, Function<? super T, ? extends V> featureFunction, Quality<? super V> delegate)
+    public Has(String featureName, ThrowingFunction<? super T, ? extends V> featureFunction, Quality<? super V> delegate)
     {
         this(new Delimited(new TextDescription("has"), new TextDescription(featureName)),
             new Delimited(new TextDescription("had"), new TextDescription(featureName)),
@@ -50,20 +55,25 @@ public final class Has<T, V> extends QualityComposition<T>
 
     public Has(Description featureDescription,
         Description featureMismatchDescription,
-        Function<? super T, ? extends V> featureFunction,
+        ThrowingFunction<? super T, ? extends V> featureFunction,
         Quality<? super V> delegate)
     {
-        super(actual -> new FailPrepended(featureMismatchDescription, delegate.assessmentOf(featureFunction.value(actual))),
-            new Delimited(featureDescription, delegate.description()));
+        this((Function<Description, Description>) delegateFeatureDescription -> new Delimited(featureDescription, delegateFeatureDescription),
+            mismatchDescription -> new Delimited(featureMismatchDescription, mismatchDescription),
+            featureFunction,
+            delegate
+        );
     }
 
 
     public Has(Function<Description, Description> featureDescription,
         Function<Description, Description> featureMismatchDescription,
-        Function<? super T, ? extends V> featureFunction,
+        ThrowingFunction<? super T, ? extends V> featureFunction,
         Quality<? super V> delegate)
     {
-        super(actual -> new FailUpdated(featureMismatchDescription, delegate.assessmentOf(featureFunction.value(actual))),
+        super(new FailSafe<>(
+                throwable -> new Fail(new Delimited(new TextDescription("threw"), new ValueDescription(throwable))),
+                actual -> new FailUpdated(featureMismatchDescription, delegate.assessmentOf(featureFunction.value(actual)))),
             featureDescription.value(delegate.description()));
     }
 }

--- a/confidence-core/src/main/java/org/saynotobugs/confidence/quality/supplier/Supplies.java
+++ b/confidence-core/src/main/java/org/saynotobugs/confidence/quality/supplier/Supplies.java
@@ -20,9 +20,8 @@ package org.saynotobugs.confidence.quality.supplier;
 
 import org.dmfs.srcless.annotations.staticfactory.StaticFactories;
 import org.saynotobugs.confidence.Quality;
-import org.saynotobugs.confidence.assessment.FailPrepended;
-import org.saynotobugs.confidence.description.Delimited;
 import org.saynotobugs.confidence.description.TextDescription;
+import org.saynotobugs.confidence.quality.composite.Has;
 import org.saynotobugs.confidence.quality.composite.QualityComposition;
 import org.saynotobugs.confidence.quality.object.EqualTo;
 
@@ -46,7 +45,6 @@ public final class Supplies<T> extends QualityComposition<Supplier<T>>
      */
     public Supplies(Quality<? super T> delegate)
     {
-        super(actual -> new FailPrepended(new TextDescription("supplied"), delegate.assessmentOf(actual.get())),
-            new Delimited(new TextDescription("supplies"), delegate.description()));
+        super(new Has<>(new TextDescription("supplies"), new TextDescription("supplied"), Supplier::get, delegate));
     }
 }

--- a/confidence-core/src/main/java/org/saynotobugs/confidence/utils/FailSafe.java
+++ b/confidence-core/src/main/java/org/saynotobugs/confidence/utils/FailSafe.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.saynotobugs.confidence.utils;
+
+import org.dmfs.jems2.Function;
+import org.dmfs.jems2.ThrowingFunction;
+
+
+/**
+ * A {@link ThrowingFunction} to {@link Function} adapter that always returns a result, even in case a {@link Throwable} was thrown.
+ */
+public final class FailSafe<Argument, Result> implements Function<Argument, Result>
+{
+    private final ThrowingFunction<Argument, Result> delegate;
+    private final Function<Throwable, Result> fallback;
+
+
+    public FailSafe(
+        Function<Throwable, Result> fallback,
+        ThrowingFunction<Argument, Result> delegate)
+    {
+        this.delegate = delegate;
+        this.fallback = fallback;
+    }
+
+
+    @Override
+    public Result value(Argument argument)
+    {
+        try
+        {
+            return delegate.value(argument);
+        }
+        catch (Throwable e)
+        {
+            return fallback.value(e);
+        }
+    }
+}

--- a/confidence-core/src/test/java/org/saynotobugs/confidence/quality/composite/HasTest.java
+++ b/confidence-core/src/test/java/org/saynotobugs/confidence/quality/composite/HasTest.java
@@ -1,6 +1,8 @@
 package org.saynotobugs.confidence.quality.composite;
 
 import org.junit.jupiter.api.Test;
+import org.saynotobugs.confidence.Description;
+import org.saynotobugs.confidence.description.Delimited;
 import org.saynotobugs.confidence.description.TextDescription;
 import org.saynotobugs.confidence.quality.object.EqualTo;
 import org.saynotobugs.confidence.test.quality.Fails;
@@ -13,13 +15,38 @@ import static org.saynotobugs.confidence.Assertion.assertThat;
 class HasTest
 {
     @Test
-    void test()
+    void testPlain()
+    {
+        assertThat(new Has<>(Object::toString, new EqualTo<>("123")),
+            new AllOf<>(
+                new Passes<>("123", 123),
+                new Fails<>(124, "\"124\""),
+                new HasDescription("\"123\"")));
+    }
+
+
+    @Test
+    void testWithFeature()
     {
         assertThat(new Has<>("toString", Object::toString, new EqualTo<>("123")),
             new AllOf<>(
                 new Passes<>("123", 123),
                 new Fails<>(124, "had toString \"124\""),
                 new HasDescription("has toString \"123\"")));
+    }
+
+
+    @Test
+    void testWithDescriptionFunction()
+    {
+        assertThat(new Has<>((Description pass) -> new Delimited(pass, new TextDescription("pass")),
+                (Description fail) -> new Delimited(fail, new TextDescription("fail")),
+                Object::toString,
+                new EqualTo<>("123")),
+            new AllOf<>(
+                new Passes<Object>("123", 123),
+                new Fails<>(124, "\"124\" fail"),
+                new HasDescription("\"123\" pass")));
     }
 
 

--- a/confidence-core/src/test/java/org/saynotobugs/confidence/quality/composite/ParallelTest.java
+++ b/confidence-core/src/test/java/org/saynotobugs/confidence/quality/composite/ParallelTest.java
@@ -3,6 +3,7 @@ package org.saynotobugs.confidence.quality.composite;
 import org.junit.jupiter.api.Test;
 import org.saynotobugs.confidence.quality.charsequence.MatchesPattern;
 import org.saynotobugs.confidence.quality.comparable.LessThan;
+import org.saynotobugs.confidence.quality.object.EqualTo;
 import org.saynotobugs.confidence.quality.supplier.Supplies;
 import org.saynotobugs.confidence.test.quality.DescribesAs;
 import org.saynotobugs.confidence.test.quality.Fails;
@@ -40,6 +41,34 @@ class ParallelTest
                     },
                     new DescribesAs(new MatchesPattern("executions: ...\\R .+ <java.lang.RuntimeException: error>\\R  ..."))),
                 new HasDescription("running 1000 parallel execution, each supplies less than <999>")
+            ));
+    }
+
+
+    @Test
+    void testError()
+    {
+        assertThat(new Parallel<>(2, new EqualTo<>(new Object()
+            {
+                @Override
+                public boolean equals(Object obj)
+                {
+                    throw new IllegalArgumentException("error");
+                }
+            })),
+            new AllOf<>(
+                new Fails<>(
+                    new Object()
+                    {
+                        @Override
+                        public boolean equals(Object obj)
+                        {
+                            throw new IllegalArgumentException("error");
+                        }
+                    },
+                    new DescribesAs(new MatchesPattern(
+                        "executions: #0 in thread .* <java.lang.IllegalArgumentException: error>,\\n  #1 in thread .* <java.lang.IllegalArgumentException: error>"))),
+                new HasDescription(new DescribesAs(new MatchesPattern("running 2 parallel execution, each .*")))
             ));
     }
 }

--- a/confidence-core/src/test/java/org/saynotobugs/confidence/utils/FailSafeTest.java
+++ b/confidence-core/src/test/java/org/saynotobugs/confidence/utils/FailSafeTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.saynotobugs.confidence.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.saynotobugs.confidence.Assertion.assertThat;
+import static org.saynotobugs.confidence.quality.Core.equalTo;
+import static org.saynotobugs.confidence.quality.Core.has;
+
+
+class FailSafeTest
+{
+    @Test
+    void testNoException()
+    {
+        assertThat(new FailSafe<String, String>(t -> "fail", x -> x),
+            has(fs -> fs.value("123"), equalTo("123")));
+    }
+
+
+    @Test
+    void testException()
+    {
+        assertThat(new FailSafe<String, String>(Throwable::getMessage, x -> {throw new IllegalArgumentException("xyz");}),
+            has(fs -> fs.value("123"), equalTo("xyz")));
+    }
+}

--- a/confidence-mockito4/build.gradle
+++ b/confidence-mockito4/build.gradle
@@ -12,10 +12,10 @@ dependencies {
     compileOnly 'org.mockito:mockito-core:4.6.1'
     compileOnly 'org.dmfs:srcless-annotations:0.1.0'
     annotationProcessor 'org.dmfs:srcless-processors:0.1.0'
-    implementation 'org.dmfs:jems2:2.8.0'
+    implementation 'org.dmfs:jems2:2.14.0'
     implementation project(':confidence-core')
     testImplementation project(':confidence-test')
-    testImplementation 'org.dmfs:jems2-testing:2.8.0'
+    testImplementation 'org.dmfs:jems2-testing:2.14.0'
     testImplementation 'org.mockito:mockito-core:4.6.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'

--- a/confidence-rxjava3/build.gradle
+++ b/confidence-rxjava3/build.gradle
@@ -11,12 +11,12 @@ targetCompatibility = JavaVersion.VERSION_1_8
 dependencies {
     compileOnly 'org.dmfs:srcless-annotations:0.1.0'
     annotationProcessor 'org.dmfs:srcless-processors:0.1.0'
-    compileOnly 'io.reactivex.rxjava3:rxjava:3.1.5'
-    implementation 'org.dmfs:jems2:2.8.0'
+    compileOnly 'io.reactivex.rxjava3:rxjava:3.1.6'
+    implementation 'org.dmfs:jems2:2.14.0'
     implementation project(':confidence-core')
     testImplementation project(':confidence-test')
     testImplementation 'io.reactivex.rxjava3:rxjava:3.1.5'
-    testImplementation 'org.dmfs:jems2-testing:2.8.0'
+    testImplementation 'org.dmfs:jems2-testing:2.14.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 }

--- a/confidence-test/build.gradle
+++ b/confidence-test/build.gradle
@@ -10,11 +10,9 @@ targetCompatibility = JavaVersion.VERSION_1_8
 dependencies {
     compileOnly 'org.dmfs:srcless-annotations:0.1.0'
     annotationProcessor 'org.dmfs:srcless-processors:0.1.0'
-    compileOnly 'org.hamcrest:hamcrest:2.2'
     implementation project(':confidence-core')
-    implementation 'org.dmfs:jems2:2.8.0'
-    testImplementation 'org.dmfs:jems2-testing:2.8.0'
-    testImplementation 'org.hamcrest:hamcrest:2.2'
+    implementation 'org.dmfs:jems2:2.14.0'
+    testImplementation 'org.dmfs:jems2-testing:2.14.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 }


### PR DESCRIPTION
This change let's the `Has` quality take a `ThrowingFunction`. This makes it easier to test method calls that may throw `Throwable`s.