### PR TITLE
CloseTo with default epsilon based on ulp, closes #84

### DIFF
--- a/confidence-core/src/main/java/org/saynotobugs/confidence/quality/number/CloseTo.java
+++ b/confidence-core/src/main/java/org/saynotobugs/confidence/quality/number/CloseTo.java
@@ -19,6 +19,7 @@
 package org.saynotobugs.confidence.quality.number;
 
 import org.dmfs.srcless.annotations.staticfactory.StaticFactories;
+import org.saynotobugs.confidence.Quality;
 import org.saynotobugs.confidence.description.Composite;
 import org.saynotobugs.confidence.description.Spaced;
 import org.saynotobugs.confidence.description.Text;
@@ -32,16 +33,57 @@ import java.math.BigDecimal;
 @StaticFactories(value = "Core", packageName = "org.saynotobugs.confidence.quality")
 public final class CloseTo extends QualityComposition<Number>
 {
-    public CloseTo(Number expectation, Number epsilon)
+    /**
+     * A {@link Quality} of a {@link Number} in that's within the given {@code ε} of one ulp as determined by {@link Math#ulp(double)}.,
+     * i.e. any number {@code x} with {@code expectation - ulp(expectation) < x < expectation + ulp(expectation)}
+     */
+    public CloseTo(double expectation)
     {
-        this(new BigDecimal(expectation.toString()), new BigDecimal(epsilon.toString()));
+        this(expectation, 1);
     }
 
 
-    public CloseTo(BigDecimal expectation, BigDecimal epsilon)
+    /**
+     * A {@link Quality} of a {@link Number} in that's within the given {@code ε} of {@code ulpCount} ulp as determined by {@link Math#ulp(double)}.,
+     * i.e. any number {@code x} with {@code expectation - ulpCount * ulp(expectation) < x < expectation + ulpCount * ulp(expectation)}
+     */
+    public CloseTo(double expectation, int ulpCount)
+    {
+        this(expectation, ulpCount * Math.ulp(expectation));
+    }
+
+    /**
+     * A {@link Quality} of a {@link Number} in that's within the given {@code ε} of one ulp as determined by {@link Math#ulp(float)}.,
+     * i.e. any number {@code x} with {@code expectation - ulp(expectation) < x < expectation + ulp(expectation)}
+     */
+    public CloseTo(float expectation)
+    {
+        this(expectation, 1);
+    }
+
+    /**
+     * A {@link Quality} of a {@link Number} in that's within the given {@code ε} of {@code ulpCount} ulp as determined by {@link Math#ulp(float)}.,
+     * i.e. any number {@code x} with {@code expectation - ulpCount * ulp(expectation) < x < expectation + ulpCount * ulp(expectation)}
+     */
+    public CloseTo(float expectation, int ulpCount)
+    {
+        this(expectation, ulpCount * Math.ulp(expectation));
+    }
+
+    /**
+     * A {@link Quality} of a {@link Number} in that's within the given {@code ε} of the given {@link Number}, i.e. any number {@code x}
+     * with {@code expectation - ε < x < expectation + ε}
+     */
+    public CloseTo(Number expectation, Number ε)
+    {
+        this(new BigDecimal(expectation.toString()), new BigDecimal(ε.toString()));
+    }
+
+
+    public CloseTo(BigDecimal expectation, BigDecimal ε)
     {
         super(new Satisfies<>(
-            actual -> expectation.subtract(new BigDecimal(actual.toString())).abs().compareTo(epsilon) <= 0,
+            actual -> expectation.subtract(new BigDecimal(actual.toString())).abs().compareTo(ε) < 0,
             actual -> new Spaced(
                 new Value(actual),
                 new Text("differs from"),
@@ -49,12 +91,12 @@ public final class CloseTo extends QualityComposition<Number>
                 new Text("by"),
                 new Composite(
                     new Value(expectation.subtract(new BigDecimal(actual.toString())).abs()),
-                    new Text(", which is more than the allowed")),
-                new Value(epsilon)),
+                    new Text(", which exceeds the ε of")),
+                new Value(ε)),
             new Spaced(
                 new Text("differs from"),
                 new Value(expectation),
-                new Text("by no more than"),
-                new Value(epsilon))));
+                new Text("by less than"),
+                new Value(ε))));
     }
 }

--- a/confidence-core/src/test/java/org/saynotobugs/confidence/quality/number/CloseToTest.java
+++ b/confidence-core/src/test/java/org/saynotobugs/confidence/quality/number/CloseToTest.java
@@ -13,14 +13,60 @@ class CloseToTest
 {
 
     @Test
-    void test()
+    void testNumber()
     {
         assertThat(new CloseTo(1.0, 0.01),
             new AllOf<>(
-                new Passes<>(1.0, 1f, 1, 1.01, 0.99),
-                new Fails<>(1.01001d, "<1.01001> differs from <1.0> by <0.01001>, which is more than the allowed <0.01>"),
-                new HasDescription("differs from <1.0> by no more than <0.01>")
+                new Passes<>(1.0, 1f, 1, 1.00999, 0.99000001),
+                new Fails<>(1.01001d, "<1.01001> differs from <1.0> by <0.01001>, which exceeds the ε of <0.01>"),
+                new HasDescription("differs from <1.0> by less than <0.01>")
             ));
     }
 
+
+    @Test
+    void testDouble1ulp()
+    {
+        assertThat(new CloseTo(1.0),
+            new AllOf<>(
+                new Passes<>(1.0000000000000001, 0.9999999999999999),
+                new Fails<>(1.01001d, "<1.01001> differs from <1.0> by <0.01001>, which exceeds the ε of <2.220446049250313E-16>"),
+                new HasDescription("differs from <1.0> by less than <2.220446049250313E-16>")
+            ));
+    }
+
+
+    @Test
+    void testDouble10ulp()
+    {
+        assertThat(new CloseTo(1.0, 10),
+            new AllOf<>(
+                new Passes<>(1.000000000000001, 0.999999999999999),
+                new Fails<>(1.01001d, "<1.01001> differs from <1.0> by <0.01001>, which exceeds the ε of <2.220446049250313E-15>"),
+                new HasDescription("differs from <1.0> by less than <2.220446049250313E-15>")
+            ));
+    }
+
+    @Test
+    void testFloat1ulp()
+    {
+        assertThat(new CloseTo(1.0f),
+            new AllOf<>(
+                new Passes<>(1.0000001, 0.9999999),
+                new Fails<>(1.01001d, "<1.01001> differs from <1.0> by <0.01001>, which exceeds the ε of <1.1920929E-7>"),
+                new HasDescription("differs from <1.0> by less than <1.1920929E-7>")
+            ));
+    }
+
+
+    @Test
+    void testFloat10ulp()
+    {
+        assertThat(new CloseTo(1.0f, 10),
+            new AllOf<>(
+                new Passes<>(1.000001, 0.999999),
+                new Fails<>(1.01001d, "<1.01001> differs from <1.0> by <0.01001>, which exceeds the ε of <0.0000011920929>"),
+                new HasDescription("differs from <1.0> by less than <0.0000011920929>")
+            ));
+    }
 }


### PR DESCRIPTION
Provides additional `closeTo` Qualities of numbers within an epsilon neighbourhood of one or n ulp.

Also changes the ε comparison from <= to < and updates the descriptions accordingly.