### PR TITLE
Add FilePosition to ClassSource, if possible. Closes #196

### DIFF
--- a/confidence-core/src/main/java/org/saynotobugs/confidence/utils/FailSafe.java
+++ b/confidence-core/src/main/java/org/saynotobugs/confidence/utils/FailSafe.java
@@ -25,7 +25,7 @@ import org.dmfs.jems2.ThrowingFunction;
 /**
  * A {@link ThrowingFunction} to {@link Function} adapter that always returns a result, even in case a {@link Throwable} was thrown.
  */
-public final class FailSafe<Argument, Result> implements Function<Argument, Result>
+public final class FailSafe<Argument, Result> implements Function<Argument, Result>, java.util.function.Function<Argument, Result>
 {
     private final ThrowingFunction<Argument, Result> delegate;
     private final Function<Throwable, Result> fallback;
@@ -51,5 +51,11 @@ public final class FailSafe<Argument, Result> implements Function<Argument, Resu
         {
             return fallback.value(e);
         }
+    }
+
+    @Override
+    public Result apply(Argument argument)
+    {
+        return value(argument);
     }
 }

--- a/confidence-core/src/test/java/org/saynotobugs/confidence/utils/FailSafeTest.java
+++ b/confidence-core/src/test/java/org/saynotobugs/confidence/utils/FailSafeTest.java
@@ -23,6 +23,8 @@ import org.saynotobugs.confidence.quality.composite.Has;
 import org.saynotobugs.confidence.quality.object.EqualTo;
 
 import static org.saynotobugs.confidence.Assertion.assertThat;
+import static org.saynotobugs.confidence.core.quality.Function.maps;
+import static org.saynotobugs.confidence.core.quality.Grammar.to;
 
 
 class FailSafeTest
@@ -42,5 +44,22 @@ class FailSafeTest
                 throw new IllegalArgumentException("xyz");
             }),
             new Has<>(fs -> fs.value("123"), new EqualTo<>("xyz")));
+    }
+
+    @Test
+    void testJavaFunctionNoException()
+    {
+        assertThat(new FailSafe<String, String>(t -> "fail", x -> x),
+            maps("123", to("123")));
+    }
+
+
+    @Test
+    void testJavaFunctionException()
+    {
+        assertThat(new FailSafe<String, String>(Throwable::getMessage, x -> {
+                throw new IllegalArgumentException("xyz");
+            }),
+            maps("123", to("xyz")));
     }
 }

--- a/confidence-incubator/build.gradle
+++ b/confidence-incubator/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation libs.junit.jupiter.engine
     implementation project(':confidence-core')
     implementation libs.jems2.confidence
+    implementation 'com.github.javaparser:javaparser-core:3.26.1'
 
     testImplementation project(':confidence-test')
     testImplementation libs.jems2.testing


### PR DESCRIPTION
This change tries to parse the Test Source file and add the Position of the Assertion Field to the ClassSource. To locate the source file, this makes some assumptions about the direcory structure and it may not work with non-standard directory names and/or trees.